### PR TITLE
Spolszczenie Mapy Skrótów

### DIFF
--- a/rdza_proc_macro/src/lib.rs
+++ b/rdza_proc_macro/src/lib.rs
@@ -7,7 +7,7 @@ fn replace_ident(ident: Ident) -> Option<TokenTree> {
         "Źle" => "Err",
         "Dobrze" => "Ok",
         "Ciąg" => "String",
-        "MapaHaszy" => "HashMap",
+        "MapaHaszy" | "MapaSkrótów" => "HashMap",
         "Wektor" => "Vec",
         "Domyślny" | "Domyślna" | "Domyślne" => "Default",
         "Błąd" => "Error",


### PR DESCRIPTION
Hash w HashMap wywodzi się od skrótów kryptograficznych.

Dodałem alternatywną wersję, by nie łamać wstecznej zgodności i zachować zasady semantycznego wersjonowania paczek. :wink: